### PR TITLE
logparser: prefer `RE_BI_HOSTCPU` for MSYS2/Cygwin shells

### DIFF
--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -262,10 +262,11 @@ def parse_buildinfo(l: str) -> TestMetaStr:
         meta['hostarch'] = r.group(1)
         # Override host detected via the MSYS2/Cygwin shells. They reflect the
         # architecture of the shell binaries, not the operating system's.
-        if (meta['systemos'].startswith('MSYS_NT')
-            or meta['systemos'].startswith('MINGW32_NT')
-            or meta['systemos'].startswith('MINGW64_NT')
-            or meta['systemos'].startswith('CYGWIN_NT')):
+        if ("systemos" in meta
+            and (meta['systemos'].startswith('MSYS_NT')
+                or meta['systemos'].startswith('MINGW32_NT')
+                or meta['systemos'].startswith('MINGW64_NT')
+                or meta['systemos'].startswith('CYGWIN_NT'))):
             meta['arch'] = meta['hostarch']
     elif r := RE_BI_HOSTOS.search(l):
         meta['hostos'] = r.group(1)

--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -260,6 +260,13 @@ def parse_buildinfo(l: str) -> TestMetaStr:
             meta['hostos'] = r.group(1)
     elif r := RE_BI_HOSTCPU.search(l):
         meta['hostarch'] = r.group(1)
+        # Override host detected via the MSYS2/Cygwin shells. They reflect the
+        # architecture of the shell binaries, not the operating system's.
+        if (meta['systemos'].startswith('MSYS_NT')
+            or meta['systemos'].startswith('MINGW32_NT')
+            or meta['systemos'].startswith('MINGW64_NT')
+            or meta['systemos'].startswith('CYGWIN_NT')):
+            meta['arch'] = meta['hostarch']
     elif r := RE_BI_HOSTOS.search(l):
         meta['hostos'] = r.group(1)
 

--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -260,7 +260,7 @@ def parse_buildinfo(l: str) -> TestMetaStr:
             meta['hostos'] = r.group(1)
     elif r := RE_BI_HOSTCPU.search(l):
         meta['hostarch'] = r.group(1)
-        # Override host detected via the MSYS2/Cygwin shells. They reflect the
+        # Override host arch detected via the MSYS2/Cygwin shells. They reflect the
         # architecture of the shell binaries, not the operating system's.
         if ('systemos' in meta
             and (meta['systemos'].startswith('MSYS_NT')

--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -262,7 +262,7 @@ def parse_buildinfo(l: str) -> TestMetaStr:
         meta['hostarch'] = r.group(1)
         # Override host detected via the MSYS2/Cygwin shells. They reflect the
         # architecture of the shell binaries, not the operating system's.
-        if ("systemos" in meta
+        if ('systemos' in meta
             and (meta['systemos'].startswith('MSYS_NT')
                 or meta['systemos'].startswith('MINGW32_NT')
                 or meta['systemos'].startswith('MINGW64_NT')

--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -260,8 +260,8 @@ def parse_buildinfo(l: str) -> TestMetaStr:
             meta['hostos'] = r.group(1)
     elif r := RE_BI_HOSTCPU.search(l):
         meta['hostarch'] = r.group(1)
-        # Override host arch detected via the MSYS2/Cygwin shells. They reflect the
-        # architecture of the shell binaries, not the operating system's.
+        # Override host arch detected via the MSYS2/Cygwin shells. This reflects
+        # the architecture of the shell binaries, not the operating system's.
         if ('systemos' in meta
             and (meta['systemos'].startswith('MSYS_NT')
                  or meta['systemos'].startswith('MINGW32_NT')

--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -264,9 +264,9 @@ def parse_buildinfo(l: str) -> TestMetaStr:
         # architecture of the shell binaries, not the operating system's.
         if ('systemos' in meta
             and (meta['systemos'].startswith('MSYS_NT')
-                or meta['systemos'].startswith('MINGW32_NT')
-                or meta['systemos'].startswith('MINGW64_NT')
-                or meta['systemos'].startswith('CYGWIN_NT'))):
+                 or meta['systemos'].startswith('MINGW32_NT')
+                 or meta['systemos'].startswith('MINGW64_NT')
+                 or meta['systemos'].startswith('CYGWIN_NT'))):
             meta['arch'] = meta['hostarch']
     elif r := RE_BI_HOSTOS.search(l):
         meta['hostos'] = r.group(1)

--- a/testclutch/uname.py
+++ b/testclutch/uname.py
@@ -60,6 +60,7 @@ def parse_uname(uname: str) -> TestMetaStr:
           or meta['systemos'].startswith('MINGW32_NT')
           or meta['systemos'].startswith('MINGW64_NT')
           or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) == 8:
+        # This reflects the architecture of the shell binaries, not the operating system's.
         meta['arch'] = sysparts[-2]
     elif (meta['systemos'].startswith('MSYS_NT')
           or meta['systemos'].startswith('MINGW32_NT')

--- a/testclutch/uname.py
+++ b/testclutch/uname.py
@@ -66,6 +66,7 @@ def parse_uname(uname: str) -> TestMetaStr:
           or meta['systemos'].startswith('MINGW64_NT')
           or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) == 7:
         # This version is missing the time zone
+        # This reflects the architecture of the shell binaries, not the operating system's.
         meta['arch'] = sysparts[-2]
     elif meta['systemos'] == 'Windows_NT' and len(syspartsblanks) == 6:
         # systemosver as set above is just the major release number


### PR DESCRIPTION
If present, it accurately reports the architecture of the operating
system, whereas the `uname -s` value used prior to this patch reports
the architecture of the MSYS2/Cygwin shell binaries. This is always
x86_64 on modern systems, even if the machine is a native ARM64 one.

Ref: https://github.com/dfandrich/testclutch/pull/2#issuecomment-4094263147
