### PR TITLE
uname: detect ARM64 machine via `uname -s` suffix on MSYS2/Cygwin

### DIFF
--- a/testclutch/logparser/curlparse.py
+++ b/testclutch/logparser/curlparse.py
@@ -260,14 +260,6 @@ def parse_buildinfo(l: str) -> TestMetaStr:
             meta['hostos'] = r.group(1)
     elif r := RE_BI_HOSTCPU.search(l):
         meta['hostarch'] = r.group(1)
-        # Override host arch detected via the MSYS2/Cygwin shells. This reflects
-        # the architecture of the shell binaries, not the operating system's.
-        if ('systemos' in meta
-            and (meta['systemos'].startswith('MSYS_NT')
-                 or meta['systemos'].startswith('MINGW32_NT')
-                 or meta['systemos'].startswith('MINGW64_NT')
-                 or meta['systemos'].startswith('CYGWIN_NT'))):
-            meta['arch'] = meta['hostarch']
     elif r := RE_BI_HOSTOS.search(l):
         meta['hostos'] = r.group(1)
 

--- a/testclutch/uname.py
+++ b/testclutch/uname.py
@@ -59,21 +59,11 @@ def parse_uname(uname: str) -> TestMetaStr:
     elif (meta['systemos'].startswith('MSYS_NT')
           or meta['systemos'].startswith('MINGW32_NT')
           or meta['systemos'].startswith('MINGW64_NT')
-          or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) == 8:
+          or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) in {7, 8}:
         if meta['systemos'].endswith('-ARM64'):
             meta['arch'] = 'ARM64'
         else:
             # This reflects the architecture of the shell binaries, not the operating system's.
-            meta['arch'] = sysparts[-2]
-    elif (meta['systemos'].startswith('MSYS_NT')
-          or meta['systemos'].startswith('MINGW32_NT')
-          or meta['systemos'].startswith('MINGW64_NT')
-          or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) == 7:
-        # This version is missing the time zone
-        # This reflects the architecture of the shell binaries, not the operating system's.
-        if meta['systemos'].endswith('-ARM64'):
-            meta['arch'] = 'ARM64'
-        else:
             meta['arch'] = sysparts[-2]
     elif meta['systemos'] == 'Windows_NT' and len(syspartsblanks) == 6:
         # systemosver as set above is just the major release number

--- a/testclutch/uname.py
+++ b/testclutch/uname.py
@@ -60,11 +60,8 @@ def parse_uname(uname: str) -> TestMetaStr:
           or meta['systemos'].startswith('MINGW32_NT')
           or meta['systemos'].startswith('MINGW64_NT')
           or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) in {7, 8}:
-        if meta['systemos'].endswith('-ARM64'):
-            meta['arch'] = 'ARM64'
-        else:
-            # This reflects the architecture of the shell binaries, not the operating system's.
-            meta['arch'] = sysparts[-2]
+        # sysparts[-2] reflects the architecture of the shell binaries, not the operating system's.
+        meta['arch'] = 'ARM64' if meta['systemos'].endswith('-ARM64') else sysparts[-2]
     elif meta['systemos'] == 'Windows_NT' and len(syspartsblanks) == 6:
         # systemosver as set above is just the major release number
         meta['systemosver'] = f'{sysparts[2]}.{sysparts[3]}'

--- a/testclutch/uname.py
+++ b/testclutch/uname.py
@@ -60,15 +60,21 @@ def parse_uname(uname: str) -> TestMetaStr:
           or meta['systemos'].startswith('MINGW32_NT')
           or meta['systemos'].startswith('MINGW64_NT')
           or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) == 8:
-        # This reflects the architecture of the shell binaries, not the operating system's.
-        meta['arch'] = sysparts[-2]
+        if meta['systemos'].endswith('-ARM64'):
+            meta['arch'] = 'ARM64'
+        else:
+            # This reflects the architecture of the shell binaries, not the operating system's.
+            meta['arch'] = sysparts[-2]
     elif (meta['systemos'].startswith('MSYS_NT')
           or meta['systemos'].startswith('MINGW32_NT')
           or meta['systemos'].startswith('MINGW64_NT')
           or meta['systemos'].startswith('CYGWIN_NT')) and len(sysparts) == 7:
         # This version is missing the time zone
         # This reflects the architecture of the shell binaries, not the operating system's.
-        meta['arch'] = sysparts[-2]
+        if meta['systemos'].endswith('-ARM64'):
+            meta['arch'] = 'ARM64'
+        else:
+            meta['arch'] = sysparts[-2]
     elif meta['systemos'] == 'Windows_NT' and len(syspartsblanks) == 6:
         # systemosver as set above is just the major release number
         meta['systemosver'] = f'{sysparts[2]}.{sysparts[3]}'

--- a/tests/test_uname.py
+++ b/tests/test_uname.py
@@ -98,6 +98,14 @@ class TestParseUname(unittest.TestCase):
             'Msys')
         )
         self.assertDictEqual({
+            'systemos': 'MINGW64_NT-10.0-26200-ARM64',
+            'systemhost': 'runnervmsa53x',
+            'systemosver': '3.6.5-0eeda3e1.x86_64',
+            'arch': 'ARM64'
+        }, uname.parse_uname(
+            'MINGW64_NT-10.0-26200-ARM64 runnervmsa53x 3.6.5-0eeda3e1.x86_64 2025-10-10 14:51 UTC x86_64 Msys')
+        )
+        self.assertDictEqual({
             'systemos': 'MINGW32_NT-10.0-17763',
             'systemhost': '68ab3802cea0',
             'systemosver': '3.4.8.x86_64',
@@ -343,30 +351,6 @@ class TestParseUname(unittest.TestCase):
             'arch': 'i386'
         }, uname.parse_uname(
             'AROS arosbox.arosnet 12.1 41 Nov 26 2018 i386 AROS')
-        )
-        self.assertDictEqual({
-            'systemos': 'MINGW64_NT-10.0-26100',
-            'systemhost': 'runnervmlbgkd',
-            'systemosver': '3.6.6-2369286a.x86_64',
-            'arch': 'x86_64'
-        }, uname.parse_uname(
-            'MINGW64_NT-10.0-26100 runnervmlbgkd 3.6.6-2369286a.x86_64 2026-01-14 12:29 UTC x86_64 Msys')
-        )
-        self.assertDictEqual({
-            'systemos': 'MINGW64_NT-10.0-26200-ARM64',
-            'systemhost': 'runnervmsa53x',
-            'systemosver': '3.6.5-0eeda3e1.x86_64',
-            'arch': 'ARM64'
-        }, uname.parse_uname(
-            'MINGW64_NT-10.0-26200-ARM64 runnervmsa53x 3.6.5-0eeda3e1.x86_64 2025-10-10 14:51 UTC x86_64 Msys')
-        )
-        self.assertDictEqual({
-            'systemos': 'CYGWIN_NT-10.0-20348',
-            'systemhost': 'runnervmixnmc',
-            'systemosver': '3.6.7-1.x86_64',
-            'arch': 'x86_64'
-        }, uname.parse_uname(
-            'CYGWIN_NT-10.0-20348 runnervmixnmc 3.6.7-1.x86_64 2026-03-02 20:13 UTC x86_64 Cygwin')
         )
 
     def test_bad_uname(self):

--- a/tests/test_uname.py
+++ b/tests/test_uname.py
@@ -360,6 +360,14 @@ class TestParseUname(unittest.TestCase):
         }, uname.parse_uname(
             'MINGW64_NT-10.0-26200-ARM64 runnervmsa53x 3.6.5-0eeda3e1.x86_64 2025-10-10 14:51 UTC x86_64 Msys')
         )
+        self.assertDictEqual({
+            'systemos': 'CYGWIN_NT-10.0-20348',
+            'systemhost': 'runnervmixnmc',
+            'systemosver': '3.6.7-1.x86_64',
+            'arch': 'x86_64'
+        }, uname.parse_uname(
+            'CYGWIN_NT-10.0-20348 runnervmixnmc 3.6.7-1.x86_64 2026-03-02 20:13 UTC x86_64 Cygwin')
+        )
 
     def test_bad_uname(self):
         self.assertDictEqual({

--- a/tests/test_uname.py
+++ b/tests/test_uname.py
@@ -344,6 +344,22 @@ class TestParseUname(unittest.TestCase):
         }, uname.parse_uname(
             'AROS arosbox.arosnet 12.1 41 Nov 26 2018 i386 AROS')
         )
+        self.assertDictEqual({
+            'systemos': 'MINGW64_NT-10.0-26100',
+            'systemhost': 'runnervmlbgkd',
+            'systemosver': '3.6.6-2369286a.x86_64',
+            'arch': 'x86_64'
+        }, uname.parse_uname(
+            'MINGW64_NT-10.0-26100 runnervmlbgkd 3.6.6-2369286a.x86_64 2026-01-14 12:29 UTC x86_64 Msys')
+        )
+        self.assertDictEqual({
+            'systemos': 'MINGW64_NT-10.0-26200-ARM64',
+            'systemhost': 'runnervmsa53x',
+            'systemosver': '3.6.5-0eeda3e1.x86_64',
+            'arch': 'ARM64'
+        }, uname.parse_uname(
+            'MINGW64_NT-10.0-26200-ARM64 runnervmsa53x 3.6.5-0eeda3e1.x86_64 2025-10-10 14:51 UTC x86_64 Msys')
+        )
 
     def test_bad_uname(self):
         self.assertDictEqual({


### PR DESCRIPTION
Also:
- curlparse.py: drop special fallback with the same goal, that relied
  on buildinfo data.
- add test case.

Refs:
https://github.com/msys2/msys2-runtime/commit/7923059bff6c120c6fb74b63c7553ea345c0a8f3
https://github.com/msys2/msys2-runtime/blob/f2802c5fefd4276aab87c8043cc9834a9b1d3808/winsup/cygwin/uname.cc#L67
https://github.com/msys2/msys2-runtime/blob/f2802c5fefd4276aab87c8043cc9834a9b1d3808/winsup/cygwin/release/3.6.0#L102-L105
https://github.com/cygwin/cygwin/commit/7923059bff6c120c6fb74b63c7553ea345c0a8f3
https://github.com/cygwin/cygwin/blob/4f9fa1ec313f93b125304c91ffe5191111e31592/winsup/cygwin/uname.cc#L47

Follow-up to 7e83d731aa1de0809d535637c11a2769fa786aee #3

---

uname output used in tests sourced from:
https://github.com/curl/curl/actions/runs/23298766818/job/67753512563#step:14:49
https://github.com/curl/curl/actions/runs/23298766818/job/67753512549#step:14:49
https://github.com/curl/curl/actions/runs/23298766818/job/67753512767#step:12:37
